### PR TITLE
Add root endpoint for MCP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,12 @@ Un alias est également disponible en :
 /wp-json/mcp/v1/config
 ```
 
+Vous pouvez également accéder à la racine de l'API en :
+
+```
+/wp-json/mcp/v1/
+```
+Cette URL renverra un court message listant les liens vers les points de terminaison importants.
+
 Si cette URL retourne une erreur (404 ou autre), vérifiez que le plugin est correctement installé et qu'aucun système de sécurité ne bloque l'accès aux routes REST.
 Si le problème persiste, rendez-vous dans **Réglages > Permaliens** de WordPress et enregistrez-les pour rafraîchir les règles de réécriture.

--- a/wordpress-mcp-full-access.php
+++ b/wordpress-mcp-full-access.php
@@ -597,6 +597,13 @@ class WP_MCP_Full_Server {
             'callback' => array($this, 'call_tool'),
             'permission_callback' => array($this, 'check_permission')
         ));
+
+        // Route racine pour indiquer les points de terminaison disponibles
+        register_rest_route($this->namespace, '/', array(
+            'methods' => 'GET',
+            'callback' => array($this, 'root_endpoint'),
+            'permission_callback' => '__return_true'
+        ));
     }
     
     /**
@@ -627,6 +634,18 @@ class WP_MCP_Full_Server {
      */
     public function check_permission() {
         return is_user_logged_in() && current_user_can('manage_options');
+    }
+
+    /**
+     * Point d'entrée racine pour orienter vers les bonnes URL
+     */
+    public function root_endpoint() {
+        return array(
+            'message' => 'Bienvenue sur l\'API MCP',
+            'config' => get_rest_url(null, 'mcp/v1/config'),
+            'info'   => get_rest_url(null, 'mcp/v1/info'),
+            'server' => get_rest_url(null, 'mcp/v1/server')
+        );
     }
     
     /**


### PR DESCRIPTION
## Summary
- add new root endpoint `/wp-json/mcp/v1/`
- document root endpoint in README

## Testing
- `php -l wordpress-mcp-full-access.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474d0348cc8320805ad9bec5e6b7bd